### PR TITLE
fix: improve type guard correctness

### DIFF
--- a/convertEdit.spec.ts
+++ b/convertEdit.spec.ts
@@ -26,6 +26,7 @@ const update: Update = {
   attributes: {
     name: 'A2',
     desc: null,
+    ['__proto__']: 'a string',
     'myns:attr': {
       value: 'value1',
       namespaceURI: 'http://example.org/myns',
@@ -54,6 +55,7 @@ const setAttributes: SetAttributes = {
   attributes: {
     name: 'A2',
     desc: null,
+    ['__proto__']: 'a string',
   },
   attributesNS: {
     'http://example.org/myns': {

--- a/convertEdit.spec.ts
+++ b/convertEdit.spec.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-expressions */
 import { expect } from '@open-wc/testing';
 
-import { Insert, Remove, Update } from './editv1.js';
+import { Update } from './editv1.js';
 
 import { convertEdit } from './convertEdit.js';
-import { SetAttributes } from './editv2.js';
+import { Insert, Remove, SetAttributes } from './editv2.js';
 
 const doc = new DOMParser().parseFromString(
   '<SCL><Substation name="AA1"></Substation></SCL>',
@@ -26,7 +26,6 @@ const update: Update = {
   attributes: {
     name: 'A2',
     desc: null,
-    ['__proto__']: 'a string',
     'myns:attr': {
       value: 'value1',
       namespaceURI: 'http://example.org/myns',
@@ -43,9 +42,9 @@ const update: Update = {
       value: 'value2',
       namespaceURI: 'http://example.org/myns2',
     },
-    attr3: {
-      value: 'value3',
-      namespaceURI: null,
+    invalid: {
+      value: 'great, but with empty namespace URI',
+      namespaceURI: '',
     },
   },
 };

--- a/convertEdit.ts
+++ b/convertEdit.ts
@@ -1,4 +1,10 @@
-import { Edit, isComplex, isNamespaced, isUpdate, Update } from './editv1.js';
+import {
+  Edit,
+  isComplexEdit,
+  isNamespaced,
+  isUpdate,
+  Update,
+} from './editv1.js';
 
 import {
   Attributes,
@@ -41,7 +47,7 @@ export function convertEdit(edit: Edit): EditV2 {
   if (isUpdate(edit)) {
     return convertUpdate(edit);
   }
-  if (isComplex(edit)) {
+  if (isComplexEdit(edit)) {
     return edit.map(convertEdit);
   }
 

--- a/convertEdit.ts
+++ b/convertEdit.ts
@@ -1,20 +1,16 @@
-import {
-  Edit,
-  isComplex,
-  isInsert,
-  isNamespaced,
-  isUpdate,
-  isRemove,
-  Update,
-} from './editv1.js';
+import { Edit, isComplex, isNamespaced, isUpdate, Update } from './editv1.js';
 
-import { EditV2 } from './editv2.js';
+import {
+  Attributes,
+  AttributesNS,
+  EditV2,
+  isInsert,
+  isRemove,
+} from './editv2.js';
 
 function convertUpdate(edit: Update): EditV2 {
-  const attributes: Partial<Record<string, string | null>> = {};
-  const attributesNS: Partial<
-    Record<string, Partial<Record<string, string | null>>>
-  > = {};
+  const attributes: Attributes = {};
+  const attributesNS: AttributesNS = {};
 
   Object.entries(edit.attributes).forEach(([key, value]) => {
     if (isNamespaced(value!)) {

--- a/convertEdit.ts
+++ b/convertEdit.ts
@@ -15,7 +15,7 @@ import {
 } from './editv2.js';
 
 function convertUpdate(edit: Update): EditV2 {
-  const attributes: AttributesV2 = {};
+  let attributes: AttributesV2 = {};
   const attributesNS: AttributesNS = {};
 
   Object.entries(edit.attributes).forEach(([key, value]) => {
@@ -28,9 +28,9 @@ function convertUpdate(edit: Update): EditV2 {
       if (!attributesNS[ns]) {
         attributesNS[ns] = {};
       }
-      attributesNS[ns][key] = value.value;
+      attributesNS[ns] = { ...attributesNS[ns], [key]: value.value };
     } else {
-      attributes[key] = value;
+      attributes = { ...attributes, [key]: value };
     }
   });
 

--- a/convertEdit.ts
+++ b/convertEdit.ts
@@ -7,7 +7,7 @@ import {
 } from './editv1.js';
 
 import {
-  Attributes,
+  AttributesV2,
   AttributesNS,
   EditV2,
   isInsert,
@@ -15,7 +15,7 @@ import {
 } from './editv2.js';
 
 function convertUpdate(edit: Update): EditV2 {
-  const attributes: Attributes = {};
+  const attributes: AttributesV2 = {};
   const attributesNS: AttributesNS = {};
 
   Object.entries(edit.attributes).forEach(([key, value]) => {

--- a/docs/plugin-api.md
+++ b/docs/plugin-api.md
@@ -52,20 +52,20 @@ Plugins communicate user intent to OpenSCD core by dispatching the following [cu
 The **edit event** allows a plugin to describe the changes it wants to make to the current `doc`.
 
 ```typescript
-export type EditDetailV2<E extends Edit = Edit> = {
+export type EditDetailV2<E extends EditV2 = EditV2> = {
   edit: E;
   title?: string;
   squash?: boolean;
 }
 
-export type EditEventV2<E extends Edit = Edit> = CustomEvent<EditDetailV2<E>>;
+export type EditEventV2<E extends EditV2 = EditV2> = CustomEvent<EditDetailV2<E>>;
 
 export type EditEventOptions = {
   title?: string;
   squash?: boolean;
 }
 
-export function newEditEventV2<E extends Edit>(edit: E, options: EditEventOptions): EditEventV2<E> {
+export function newEditEventV2<E extends EditV2>(edit: E, options: EditEventOptions): EditEventV2<E> {
   return new CustomEvent<E>('oscd-edit-v2', {
     composed: true,
     bubbles: true,
@@ -84,7 +84,7 @@ Its `title` property is a human-readable description of the edit.
 
 The `squash` flag indicates whether the edit should be merged with the previous edit in the history.
 
-#### `Edit` type
+#### `EditV2` type
 The `EditDetailV2` defined above contains an `edit` of this type:
 
 ```typescript
@@ -149,86 +149,6 @@ export function newOpenEvent(doc: XMLDocument, docName: string): OpenEvent {
 declare global {
   interface ElementEventMap {
     ['oscd-open']: OpenEvent;
-  }
-}
-```
-
-### `WizardEvent`
-
-The **wizard event** allows the plugin to request opening a modal dialog enabling the user to edit an arbitrary SCL `element`, regardless of how the dialog for editing this particular type of element looks and works.
-
-```typescript
-/* eslint-disable no-undef */
-interface WizardRequestBase {
-  subWizard?: boolean; // TODO: describe what this currently means
-}
-
-export interface EditWizardRequest extends WizardRequestBase {
-  element: Element;
-}
-
-export interface CreateWizardRequest extends WizardRequestBase {
-  parent: Element;
-  tagName: string;
-}
-
-export type WizardRequest = EditWizardRequest | CreateWizardRequest;
-
-type EditWizardEvent = CustomEvent<EditWizardRequest>;
-type CreateWizardEvent = CustomEvent<CreateWizardRequest>;
-export type WizardEvent = EditWizardEvent | CreateWizardEvent;
-
-type CloseWizardEvent = CustomEvent<WizardRequest>;
-
-export function newEditWizardEvent(
-  element: Element,
-  subWizard?: boolean,
-  eventInitDict?: CustomEventInit<Partial<EditWizardRequest>>
-): EditWizardEvent {
-  return new CustomEvent<EditWizardRequest>('oscd-edit-wizard-request', {
-    bubbles: true,
-    composed: true,
-    ...eventInitDict,
-    detail: { element, subWizard, ...eventInitDict?.detail },
-  });
-}
-
-export function newCreateWizardEvent(
-  parent: Element,
-  tagName: string,
-  subWizard?: boolean,
-  eventInitDict?: CustomEventInit<Partial<CreateWizardRequest>>
-): CreateWizardEvent {
-  return new CustomEvent<CreateWizardRequest>('oscd-create-wizard-request', {
-    bubbles: true,
-    composed: true,
-    ...eventInitDict,
-    detail: {
-      parent,
-      tagName,
-      subWizard,
-      ...eventInitDict?.detail,
-    },
-  });
-}
-
-export function newCloseWizardEvent(
-  wizard: WizardRequest,
-  eventInitDict?: CustomEventInit<Partial<WizardRequest>>
-): CloseWizardEvent {
-  return new CustomEvent<WizardRequest>('oscd-close-wizard', {
-    bubbles: true,
-    composed: true,
-    ...eventInitDict,
-    detail: wizard,
-  });
-}
-
-declare global {
-  interface ElementEventMap {
-    ['oscd-edit-wizard-request']: EditWizardRequest;
-    ['oscd-create-wizard-request']: CreateWizardRequest;
-    ['oscd-close-wizard']: WizardEvent;
   }
 }
 ```

--- a/edit-event-v2.ts
+++ b/edit-event-v2.ts
@@ -1,0 +1,33 @@
+import { EditV2 } from './editv2.js';
+
+export type EditDetailV2<E extends EditV2 = EditV2> = {
+  edit: E;
+  title?: string;
+  squash?: boolean;
+};
+
+export type EditEventV2<E extends EditV2 = EditV2> = CustomEvent<
+  EditDetailV2<E>
+>;
+
+export type EditEventOptions = {
+  title?: string;
+  squash?: boolean;
+};
+
+export function newEditEventV2<E extends EditV2>(
+  edit: E,
+  options?: EditEventOptions,
+): EditEventV2<E> {
+  return new CustomEvent<EditDetailV2<E>>('oscd-edit-v2', {
+    composed: true,
+    bubbles: true,
+    detail: { ...options, edit },
+  });
+}
+
+declare global {
+  interface ElementEventMap {
+    ['oscd-edit-v2']: EditEventV2<EditV2>;
+  }
+}

--- a/edit-event.ts
+++ b/edit-event.ts
@@ -1,33 +1,17 @@
-import { EditV2 } from './editv2.js';
+import { Edit } from './editv1.js';
 
-export type EditDetailV2<E extends EditV2 = EditV2> = {
-  edit: E;
-  title?: string;
-  squash?: boolean;
-};
+export type EditEvent<E extends Edit = Edit> = CustomEvent<E>;
 
-export type EditEventV2<E extends EditV2 = EditV2> = CustomEvent<
-  EditDetailV2<E>
->;
-
-export type EditEventOptions = {
-  title?: string;
-  squash?: boolean;
-};
-
-export function newEditEventV2<E extends EditV2>(
-  edit: E,
-  options?: EditEventOptions,
-): EditEventV2<E> {
-  return new CustomEvent<EditDetailV2<E>>('oscd-edit-v2', {
+export function newEditEvent<E extends Edit>(edit: E): EditEvent<E> {
+  return new CustomEvent<E>('oscd-edit-v2', {
     composed: true,
     bubbles: true,
-    detail: { ...options, edit },
+    detail: edit,
   });
 }
 
 declare global {
   interface ElementEventMap {
-    ['oscd-edit-v2']: EditEventV2;
+    ['oscd-edit']: EditEvent<Edit>;
   }
 }

--- a/editv1.spec.ts
+++ b/editv1.spec.ts
@@ -28,14 +28,11 @@ describe('type guard functions for editv1', () => {
 
   it('returns true for Remove', () => expect(remove).to.satisfy(isEdit));
 
-  it('returns false for SetAttributes', () =>
-    expect(setAttributes).to.not.satisfy(isEdit));
-
   it('returns true for SetTextContent', () =>
     expect(setTextContent).to.not.satisfy(isEdit));
 
   it('returns false on mixed edit and editV2 array', () =>
-    expect([update, setAttributes]).to.not.satisfy(isEdit));
+    expect([update, setTextContent]).to.not.satisfy(isEdit));
 
   it('returns true on edit array', () =>
     expect([update, remove, insert]).to.satisfy(isEdit));

--- a/editv1.ts
+++ b/editv1.ts
@@ -7,7 +7,7 @@ export type NamespacedAttributeValue = {
 
 export type AttributeValue = string | null | NamespacedAttributeValue;
 
-export type AttributesV1 = Partial<Record<string, AttributeValue>>;
+export type Attributes = Partial<Record<string, AttributeValue>>;
 
 /** Intent to set or remove (if null) attributes on element */
 export type Update = {
@@ -31,9 +31,7 @@ export function isNamespaced(
   );
 }
 
-export function isAttributesV1(
-  attributes: unknown,
-): attributes is AttributesV1 {
+export function isAttributes(attributes: unknown): attributes is Attributes {
   if (attributes === null || typeof attributes !== 'object') {
     return false;
   }
@@ -52,7 +50,7 @@ export function isComplexEdit(edit: unknown): edit is Edit[] {
 export function isUpdate(edit: unknown): edit is Update {
   return (
     (edit as Update).element instanceof Element &&
-    isAttributesV1((edit as Update).attributes)
+    isAttributes((edit as Update).attributes)
   );
 }
 

--- a/editv1.ts
+++ b/editv1.ts
@@ -45,7 +45,7 @@ export function isAttributesV1(
   );
 }
 
-export function isComplex(edit: unknown): edit is Edit[] {
+export function isComplexEdit(edit: unknown): edit is Edit[] {
   return edit instanceof Array && edit.every(isEdit);
 }
 
@@ -56,10 +56,8 @@ export function isUpdate(edit: unknown): edit is Update {
   );
 }
 
-export type EditEvent<E extends Edit = Edit> = CustomEvent<E>;
-
 export function isEdit(edit: unknown): edit is Edit {
-  if (isComplex(edit)) {
+  if (isComplexEdit(edit)) {
     return true;
   }
 

--- a/editv2.spec.ts
+++ b/editv2.spec.ts
@@ -19,16 +19,16 @@ const insert: Insert = { parent: element, node: element, reference: null };
 const remove: Remove = { node: element };
 const setAttributes: SetAttributes = {
   element,
-  attributes: {},
-  attributesNS: {},
+  attributes: { name: 'value' },
+  attributesNS: { namespaceURI: { name: 'value' } },
 };
 const setTextContent: SetTextContent = { element, textContent: '' };
 
-describe('type guard functions for editv2', () => {
-  it('returns false on invalid Edit type', () =>
+describe('isEditV2', () => {
+  it('returns false for invalid Edit type', () =>
     expect('invalid edit').to.not.satisfy(isEditV2));
 
-  it('returns false on Update', () => expect(update).to.not.satisfy(isEditV2));
+  it('returns false for Update', () => expect(update).to.not.satisfy(isEditV2));
 
   it('returns true for Insert', () => expect(insert).to.satisfy(isEditV2));
 
@@ -40,13 +40,13 @@ describe('type guard functions for editv2', () => {
   it('returns true for SetTextContent', () =>
     expect(setTextContent).to.satisfy(isEditV2));
 
-  it('returns false on mixed edit and editV2 array', () =>
+  it('returns false for a mixed edit and editV2 array', () =>
     expect([update, setAttributes]).to.not.satisfy(isEditV2));
 
-  it('returns false on edit array', () =>
+  it('returns false for edit array', () =>
     expect([update, update]).to.not.satisfy(isEditV2));
 
-  it('returns true on editV2 array', () =>
+  it('returns true for editV2 array', () =>
     expect([setAttributes, remove, insert, setTextContent]).to.satisfy(
       isEditV2,
     ));

--- a/editv2.ts
+++ b/editv2.ts
@@ -17,16 +17,16 @@ export type SetTextContent = {
 };
 
 /** Record from attribute names to attribute values */
-export type Attributes = Partial<Record<string, string | null>>;
+export type AttributesV2 = Partial<Record<string, string | null>>;
 
 /** Record from namespace URIs to `Attributes` records */
-export type AttributesNS = Partial<Record<string, Attributes>>;
+export type AttributesNS = Partial<Record<string, AttributesV2>>;
 
 /** Intent to set or remove (if `null`) `attributes`(-`NS`) on `element` */
 export type SetAttributes = {
   element: Element;
-  attributes: Attributes;
-  attributesNS: AttributesNS;
+  attributes?: AttributesV2;
+  attributesNS?: AttributesNS;
 };
 
 /** Intent to change some XMLDocuments */
@@ -37,7 +37,9 @@ export type EditV2 =
   | Remove
   | EditV2[];
 
-export function isAttributes(attributes: unknown): attributes is Attributes {
+export function isAttributesV2(
+  attributes: unknown,
+): attributes is AttributesV2 {
   if (typeof attributes !== 'object' || attributes === null) {
     return false;
   }
@@ -56,7 +58,7 @@ export function isAttributesNS(
   return Object.entries(attributesNS).every(
     ([namespace, attributes]) =>
       typeof namespace === 'string' &&
-      isAttributes(attributes as Record<string, string | null>),
+      isAttributesV2(attributes as Record<string, string | null>),
   );
 }
 
@@ -81,7 +83,7 @@ export function isRemove(edit: unknown): edit is Remove {
 export function isSetAttributes(edit: unknown): edit is SetAttributes {
   return (
     (edit as SetAttributes).element instanceof Element &&
-    isAttributes((edit as SetAttributes).attributes) &&
+    isAttributesV2((edit as SetAttributes).attributes) &&
     isAttributesNS((edit as SetAttributes).attributesNS)
   );
 }

--- a/editv2.ts
+++ b/editv2.ts
@@ -58,7 +58,7 @@ export function isAttributesNS(
   );
 }
 
-export function isComplex(edit: unknown): edit is EditV2[] {
+export function isComplexEditV2(edit: unknown): edit is EditV2[] {
   return edit instanceof Array && edit.every(e => isEditV2(e));
 }
 
@@ -96,7 +96,7 @@ export function isInsert(edit: unknown): edit is Insert {
 }
 
 export function isEditV2(edit: unknown): edit is EditV2 {
-  if (isComplex(edit)) {
+  if (isComplexEditV2(edit)) {
     return true;
   }
 

--- a/editv2.ts
+++ b/editv2.ts
@@ -16,15 +16,17 @@ export type SetTextContent = {
   textContent: string;
 };
 
+/** Record from attribute names to attribute values */
 export type Attributes = Partial<Record<string, string | null>>;
 
+/** Record from namespace URIs to `Attributes` records */
 export type AttributesNS = Partial<Record<string, Attributes>>;
 
 /** Intent to set or remove (if `null`) `attributes`(-`NS`) on `element` */
 export type SetAttributes = {
   element: Element;
-  attributes: Partial<Record<string, string | null>>;
-  attributesNS: Partial<Record<string, Partial<Record<string, string | null>>>>;
+  attributes: Attributes;
+  attributesNS: AttributesNS;
 };
 
 /** Intent to change some XMLDocuments */

--- a/open-event.ts
+++ b/open-event.ts
@@ -1,0 +1,21 @@
+export type OpenDetail = {
+  doc: XMLDocument;
+  docName: string;
+};
+
+/** Represents the intent to open `doc` with filename `docName`. */
+export type OpenEvent = CustomEvent<OpenDetail>;
+
+export function newOpenEvent(doc: XMLDocument, docName: string): OpenEvent {
+  return new CustomEvent<OpenDetail>('oscd-open', {
+    bubbles: true,
+    composed: true,
+    detail: { doc, docName },
+  });
+}
+
+declare global {
+  interface ElementEventMap {
+    ['oscd-open']: OpenEvent;
+  }
+}

--- a/oscd-api.ts
+++ b/oscd-api.ts
@@ -28,3 +28,5 @@ export type {
   EditEventOptions,
   EditEventV2,
 } from './edit-event.js';
+
+export type { OpenDetail, OpenEvent } from './open-event.js';

--- a/oscd-api.ts
+++ b/oscd-api.ts
@@ -1,35 +1,20 @@
-export {
+export type {
   Attributes,
   AttributesNS,
   EditV2,
   Insert,
-  isAttributes,
-  isAttributesNS,
-  isComplexEditV2,
-  isEditV2,
-  isInsert,
-  isRemove,
-  isSetAttributes,
-  isSetTextContent,
   Remove,
   SetAttributes,
   SetTextContent,
 } from './editv2.js';
 
-export {
+export type {
   AttributesV1,
   AttributeValue,
   Edit,
-  isAttributesV1,
-  isComplexEdit,
-  isEdit,
-  isNamespaced,
-  isUpdate,
   NamespacedAttributeValue,
   Update,
 } from './editv1.js';
-
-export { convertEdit } from './convertEdit.js';
 
 export type {
   Commit,
@@ -38,9 +23,8 @@ export type {
   TransactedCallback,
 } from './Transactor.js';
 
-export {
+export type {
   EditDetailV2,
   EditEventOptions,
   EditEventV2,
-  newEditEventV2,
 } from './edit-event.js';

--- a/oscd-api.ts
+++ b/oscd-api.ts
@@ -1,18 +1,35 @@
 export {
+  Attributes,
+  AttributesNS,
   EditV2,
   Insert,
-  Remove,
-  SetAttributes,
-  SetTextContent,
-  isComplex,
+  isAttributes,
+  isAttributesNS,
+  isComplexEditV2,
   isEditV2,
   isInsert,
   isRemove,
   isSetAttributes,
   isSetTextContent,
+  Remove,
+  SetAttributes,
+  SetTextContent,
 } from './editv2.js';
 
-export { Edit, Update, isEdit } from './editv1.js';
+export {
+  AttributesV1,
+  AttributeValue,
+  Edit,
+  isAttributesV1,
+  isComplexEdit,
+  isEdit,
+  isNamespaced,
+  isUpdate,
+  NamespacedAttributeValue,
+  Update,
+} from './editv1.js';
+
+export { convertEdit } from './convertEdit.js';
 
 export type {
   Commit,
@@ -21,4 +38,9 @@ export type {
   TransactedCallback,
 } from './Transactor.js';
 
-export { newEditEventV2 } from './edit-event.js';
+export {
+  EditDetailV2,
+  EditEventOptions,
+  EditEventV2,
+  newEditEventV2,
+} from './edit-event.js';

--- a/oscd-api.ts
+++ b/oscd-api.ts
@@ -23,10 +23,12 @@ export type {
   TransactedCallback,
 } from './Transactor.js';
 
+export type { EditEvent } from './edit-event.js';
+
 export type {
   EditDetailV2,
   EditEventOptions,
   EditEventV2,
-} from './edit-event.js';
+} from './edit-event-v2.js';
 
 export type { OpenDetail, OpenEvent } from './open-event.js';

--- a/oscd-api.ts
+++ b/oscd-api.ts
@@ -1,5 +1,5 @@
 export type {
-  Attributes,
+  AttributesV2,
   AttributesNS,
   EditV2,
   Insert,
@@ -9,7 +9,7 @@ export type {
 } from './editv2.js';
 
 export type {
-  AttributesV1,
+  Attributes,
   AttributeValue,
   Edit,
   NamespacedAttributeValue,

--- a/package.json
+++ b/package.json
@@ -3,8 +3,16 @@
   "version": "0.0.14",
   "description": "OpenSCD API for IEC 61850 SCL files",
   "type": "module",
-  "main": "./dist/oscd-api.js",
-  "types": "./dist/oscd-api.d.ts",
+  "exports": {
+    ".": {
+      "default": "./dist/oscd-api.js",
+      "types": "./dist/oscd-api.d.ts"
+    },
+    "./utils.js": {
+      "default": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
+    }
+  },
   "scripts": {
     "lint": "eslint . && prettier \"**/*.ts\" --check --ignore-path .gitignore",
     "format": "eslint ./*.ts --fix",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     ],
     "rules": {
       "no-unused-vars": "off",
+      "no-use-before-define": "off",
       "class-methods-use-this": [
         "error",
         {

--- a/utils.ts
+++ b/utils.ts
@@ -1,5 +1,5 @@
 export {
-  isAttributes,
+  isAttributesV2,
   isAttributesNS,
   isComplexEditV2,
   isEditV2,
@@ -10,7 +10,7 @@ export {
 } from './editv2.js';
 
 export {
-  isAttributesV1,
+  isAttributes,
   isComplexEdit,
   isEdit,
   isNamespaced,

--- a/utils.ts
+++ b/utils.ts
@@ -1,0 +1,22 @@
+export {
+  isAttributes,
+  isAttributesNS,
+  isComplexEditV2,
+  isEditV2,
+  isInsert,
+  isRemove,
+  isSetAttributes,
+  isSetTextContent,
+} from './editv2.js';
+
+export {
+  isAttributesV1,
+  isComplexEdit,
+  isEdit,
+  isNamespaced,
+  isUpdate,
+} from './editv1.js';
+
+export { convertEdit } from './convertEdit.js';
+
+export { newEditEventV2 } from './edit-event.js';

--- a/utils.ts
+++ b/utils.ts
@@ -19,6 +19,8 @@ export {
 
 export { convertEdit } from './convertEdit.js';
 
-export { newEditEventV2 } from './edit-event.js';
+export { newEditEvent } from './edit-event.js';
+
+export { newEditEventV2 } from './edit-event-v2.js';
 
 export { newOpenEvent } from './open-event.js';

--- a/utils.ts
+++ b/utils.ts
@@ -20,3 +20,5 @@ export {
 export { convertEdit } from './convertEdit.js';
 
 export { newEditEventV2 } from './edit-event.js';
+
+export { newOpenEvent } from './open-event.js';


### PR DESCRIPTION
Also, add OpenEvent.
Also, add some documentation.
Also, remove wizards from the markdown API doc.
Also, move utils to a separate module.
Also, expose the module members that were still missing.

Sorry for the big pull request.