### PR TITLE
feat: add timestamp to commit definition

### DIFF
--- a/src/Transactor.ts
+++ b/src/Transactor.ts
@@ -15,6 +15,8 @@ export interface Commit<Change> {
   redo: Change[];
   /** An optional human-readable description of the committed changes */
   title?: string;
+  /** Time of creation (milliseconds from epoch) */
+  time: number;
 }
 export type TransactedCallback<Change> = (txRecord: Commit<Change>) => void;
 /**


### PR DESCRIPTION
Release-As: 0.1.6

This mini-feature adds a time field to the Commit object